### PR TITLE
Adding support for specifying a tuner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ You can edit these settings via the `config/config.toml` file.
 
 ```toml
 hdhomerun_host = "192.168.1.13"
+hdhomerun_tuner = "auto"
 ffmpeg_path = "/usr/local/bin/ffmpeg"
 transcoding_path = "./tmp"
 port = "8888"
@@ -126,6 +127,9 @@ hd_start = 500
 
 ##### `hdhomerun_host`
 The IP address of your HDHomeRun Prime on your network.
+
+##### `hdhomerun_tuner`
+This is the tuner on the hdhomerun that wallop will use. Since the HDHomeRun PRIME has 3 tuners, the options are "tuner0", "tuner1", "tuner2", or "auto" (default).
 
 ##### `ffmpeg_path`
 The path to your FFMPEG binary.

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,4 +1,5 @@
 hdhomerun_host = "192.168.1.13"
+hdhomerun_tuner = "auto"
 ffmpeg_path = "/usr/local/bin/ffmpeg"
 transcoding_path = "./tmp"
 port = "8888"

--- a/lib/wallop.rb
+++ b/lib/wallop.rb
@@ -90,7 +90,7 @@ module Wallop
   end
 
   def self.raw_stream_url_for_channel(channel)
-    "http://#{config['hdhomerun_host']}:5004/auto/v#{channel}"
+    "http://#{config['hdhomerun_host']}:5004/#{config['hdhomerun_tuner']}/v#{channel}"
   end
 
   def self.hdhomerun_lineup_url


### PR DESCRIPTION
I wanted to ability to specify the tuner in the configuration file. This lets me run two (or three) instances of wallop on different ports that stream from different tuners, allowing two different clients to watch two different channels without messing with each others tuned channels.
