### PR TITLE
Support HDHR Extend with built-in transcoding

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -63,10 +63,12 @@ module Wallop
       if !Wallop.sessions.has_key?(channel)
         Wallop.cleanup_channel(channel)
         if Wallop.config['hdhr_transcode']
+          ## validate transcode profile
           profile = params[:profile] =~ /\A[a-z]+\d*\z/ ? params[:profile] : 'heavy'
           Wallop.logger.info "Tuning channel #{channel} with transcode profile #{profile}"
           pid  = POSIX::Spawn::spawn(Wallop.ffmpeg_no_transcode_command(channel, profile))
         else
+          ## validate resolution and bitrate
           resolution = params[:resolution] =~ /\A\d+x\d+\z/ ? params[:resolution] : '1280x720'
           bitrate = params[:bitrate] =~ /\A\d+k\z/ ? params[:bitrate] : '3000k'
           Wallop.logger.info "Tuning channel #{channel} with quality settings of #{resolution} @ #{bitrate}"

--- a/app/public/js/src/channel.coffee
+++ b/app/public/js/src/channel.coffee
@@ -8,7 +8,7 @@ $ ->
     $('#video-player').data('status-url')
 
   tuneUrl = ->
-    $('#video-player').data('tune-url') + "?resolution=" + resolution() + "&bitrate=" + bitrate()
+    $('#video-player').data('tune-url') + "?resolution=" + resolution() + "&bitrate=" + bitrate() + "&profile=" + profile() 
 
   playUrl = ->
     $('#video-player').data('play-url')
@@ -18,6 +18,9 @@ $ ->
 
   resolution = ->
     localStorage.resolution || "1280x720"
+
+  profile = ->
+    localStorage.profile || "heavy"
 
   startLoading = (title=null, message=null) ->
     spinOpts = {

--- a/app/public/js/src/settings.coffee
+++ b/app/public/js/src/settings.coffee
@@ -6,6 +6,9 @@ $ ->
   resolution = ->
     localStorage.resolution || "1280x720"
 
+  profile = ->
+    localStorage.profile || "heavy"
+
   loadSettings = ->
     $('.resolution-setting').each (i, e)  =>
       if $(e).val() == resolution()
@@ -15,6 +18,9 @@ $ ->
       if $(e).val() == bitrate()
         $(e).attr('checked', 'checked')
 
+    $('.profile-setting').each (i, e)  =>
+      if $(e).val() == profile()
+        $(e).attr('checked', 'checked')
 
   $('.resolution-setting').change ->
     self = $(this)
@@ -23,6 +29,10 @@ $ ->
   $('.bitrate-setting').change ->
     self = $(this)
     localStorage.bitrate = self.val()
+
+  $('.profile-setting').change ->
+    self = $(this)
+    localStorage.profile = self.val()
 
 
 

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -64,63 +64,93 @@
       </div>
       <div class="modal-body">
 
-      <h4>Resolution</h4>
-      <label class="radio">
-        <input class="resolution-setting" name="resolution" type="radio" value="640x360">
-        640x360
-      </label>
-      <label class="radio">
-        <input class="resolution-setting" name="resolution" type="radio" value="640x480">
-        640x480
-      </label>
-      <label class="radio">
-        <input class="resolution-setting" name="resolution" type="radio" value="720x480">
-        720x480
-      </label>
-      <label class="radio">
-        <input class="resolution-setting" name="resolution" type="radio" value="1280x720">
-        1280x720
-      </label>
-      <label class="radio">
-        <input class="resolution-setting" name="resolution" type="radio" value="1920x1080">
-        1920x1080
-      </label>
+      <% if Wallop.config['hdhr_transcode'] %>
+          <h4>Transcode Profile</h4>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="heavy">
+            heavy
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="mobile">
+            mobile
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="internet720">
+            internet720
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="internet540">
+            internet540
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="internet480">
+            internet480
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="internet360">
+            internet360
+          </label>
+          <label class="radio">
+            <input class="profile-setting" name="profile" type="radio" value="internet240">
+            internet240
+          </label>
+      <% else %>
+          <h4>Resolution</h4>
+          <label class="radio">
+            <input class="resolution-setting" name="resolution" type="radio" value="640x360">
+            640x360
+          </label>
+          <label class="radio">
+            <input class="resolution-setting" name="resolution" type="radio" value="640x480">
+            640x480
+          </label>
+          <label class="radio">
+            <input class="resolution-setting" name="resolution" type="radio" value="720x480">
+            720x480
+          </label>
+          <label class="radio">
+            <input class="resolution-setting" name="resolution" type="radio" value="1280x720">
+            1280x720
+          </label>
+          <label class="radio">
+            <input class="resolution-setting" name="resolution" type="radio" value="1920x1080">
+            1920x1080
+          </label>
 
-      <h4>Bitrate</h4>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="320k">
-        320kbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="720k">
-        720kbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="1000k">
-        1mbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="2000k">
-        2mbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="3000k">
-        3mbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="4000k">
-        4mbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="6000k">
-        6mbps
-      </label>
-      <label class="radio">
-        <input class="bitrate-setting" name="bitrate" type="radio" value="8000k">
-        8mbps
-      </label>
-
-
+          <h4>Bitrate</h4>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="320k">
+            320kbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="720k">
+            720kbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="1000k">
+            1mbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="2000k">
+            2mbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="3000k">
+            3mbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="4000k">
+            4mbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="6000k">
+            6mbps
+          </label>
+          <label class="radio">
+            <input class="bitrate-setting" name="bitrate" type="radio" value="8000k">
+            8mbps
+          </label>
+      <% end %>
 
       </div>
       <div class="modal-footer">

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -68,31 +68,27 @@
           <h4>Transcode Profile</h4>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="heavy">
-            heavy
+            Original resolution and frame rate
           </label>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="mobile">
-            mobile
-          </label>
-          <label class="radio">
-            <input class="profile-setting" name="profile" type="radio" value="internet720">
-            internet720
+            1280x720 30fps
           </label>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="internet540">
-            internet540
+            960x540 30fps low bitrate
           </label>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="internet480">
-            internet480
+            848x480 30fps low bitrate
           </label>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="internet360">
-            internet360
+            640x360 30fps low bitrate
           </label>
           <label class="radio">
             <input class="profile-setting" name="profile" type="radio" value="internet240">
-            internet240
+            432x240 30fps low bitrate
           </label>
       <% else %>
           <h4>Resolution</h4>

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,4 +1,5 @@
 hdhomerun_host = "192.168.1.13"
+hdhr_transcode = false
 ffmpeg_path = "/usr/local/bin/ffmpeg"
 transcoding_path = "./tmp"
 port = "8888"

--- a/lib/wallop.rb
+++ b/lib/wallop.rb
@@ -29,6 +29,10 @@ module Wallop
     %{exec #{config['ffmpeg_path']} -threads #{config['ffmpeg']['threads']} -f mpegts -analyzeduration 2000000 -i #{raw_stream_url_for_channel(channel)} -ac 2 -acodec #{config['ffmpeg']['acodec']} -b:v #{bitrate} -bufsize #{bitrate.to_i*2}k -minrate #{bitrate.gsub(/\d+/){ |o| (o.to_i * 0.80).to_i }} -maxrate #{bitrate} -vcodec libx264 -s #{resolution} -preset #{config['ffmpeg']['h264_preset']} -r #{config['ffmpeg']['framerate']} -hls_time #{config['ffmpeg']['hls_time']} -hls_wrap #{config['ffmpeg']['hls_wrap']} #{config['ffmpeg']['options']} #{transcoding_path}/#{channel}.m3u8 >log/ffmpeg.log 2>&1}
   end
 
+  def self.ffmpeg_no_transcode_command(channel, profile='heavy')
+    %{exec #{config['ffmpeg_path']} -threads #{config['ffmpeg']['threads']} -f mpegts -analyzeduration 2000000 -i #{raw_stream_url_for_channel(channel)}?transcode=#{profile} -ac 2 -acodec #{config['ffmpeg']['acodec']} -vcodec copy -hls_time #{config['ffmpeg']['hls_time']} -hls_wrap #{config['ffmpeg']['hls_wrap']} #{config['ffmpeg']['options']} #{transcoding_path}/#{channel}.m3u8 >log/ffmpeg.log 2>&1}
+  end
+
   def self.snapshot_command(channel, width=nil)
     width ||= 'iw/3'
     file = "#{channel}-#{Time.now.to_i}.png"


### PR DESCRIPTION
This PR enables using the HDHR Extend model's ability to trancode MPEG2 content itself. When used this way, ffmpeg doesn't have to transcode video, meaning it can run on less capable hardware. I have used this patch on a Raspberry Pi model 1.

The HDHR transcode support is enabled by setting hdhr_transcode = true in config.toml.