### PR TITLE
Change default HDHR transcoding profile to mobile (1280x720) 

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -64,7 +64,7 @@ module Wallop
         Wallop.cleanup_channel(channel)
         if Wallop.config['hdhr_transcode']
           ## validate transcode profile
-          profile = params[:profile] =~ /\A[a-z]+\d*\z/ ? params[:profile] : 'heavy'
+          profile = params[:profile] =~ /\A[a-z]+\d*\z/ ? params[:profile] : 'mobile'
           Wallop.logger.info "Tuning channel #{channel} with transcode profile #{profile}"
           pid  = POSIX::Spawn::spawn(Wallop.ffmpeg_no_transcode_command(channel, profile))
         else

--- a/app/public/js/src/channel.coffee
+++ b/app/public/js/src/channel.coffee
@@ -20,7 +20,7 @@ $ ->
     localStorage.resolution || "1280x720"
 
   profile = ->
-    localStorage.profile || "heavy"
+    localStorage.profile || "mobile"
 
   startLoading = (title=null, message=null) ->
     spinOpts = {

--- a/app/public/js/src/settings.coffee
+++ b/app/public/js/src/settings.coffee
@@ -7,7 +7,7 @@ $ ->
     localStorage.resolution || "1280x720"
 
   profile = ->
-    localStorage.profile || "heavy"
+    localStorage.profile || "mobile"
 
   loadSettings = ->
     $('.resolution-setting').each (i, e)  =>

--- a/lib/wallop.rb
+++ b/lib/wallop.rb
@@ -29,7 +29,7 @@ module Wallop
     %{exec #{config['ffmpeg_path']} -threads #{config['ffmpeg']['threads']} -f mpegts -analyzeduration 2000000 -i #{raw_stream_url_for_channel(channel)} -ac 2 -acodec #{config['ffmpeg']['acodec']} -b:v #{bitrate} -bufsize #{bitrate.to_i*2}k -minrate #{bitrate.gsub(/\d+/){ |o| (o.to_i * 0.80).to_i }} -maxrate #{bitrate} -vcodec libx264 -s #{resolution} -preset #{config['ffmpeg']['h264_preset']} -r #{config['ffmpeg']['framerate']} -hls_time #{config['ffmpeg']['hls_time']} -hls_wrap #{config['ffmpeg']['hls_wrap']} #{config['ffmpeg']['options']} #{transcoding_path}/#{channel}.m3u8 >log/ffmpeg.log 2>&1}
   end
 
-  def self.ffmpeg_no_transcode_command(channel, profile='heavy')
+  def self.ffmpeg_no_transcode_command(channel, profile='mobile')
     %{exec #{config['ffmpeg_path']} -threads #{config['ffmpeg']['threads']} -f mpegts -analyzeduration 2000000 -i #{raw_stream_url_for_channel(channel)}?transcode=#{profile} -ac 2 -acodec #{config['ffmpeg']['acodec']} -vcodec copy -hls_time #{config['ffmpeg']['hls_time']} -hls_wrap #{config['ffmpeg']['hls_wrap']} #{config['ffmpeg']['options']} #{transcoding_path}/#{channel}.m3u8 >log/ffmpeg.log 2>&1}
   end
 


### PR DESCRIPTION
Mobile (1280x720, 30fps) is probably a better bandwidth/quality tradeoff for most people, plus it gives more reliable streaming with [roku-hdhomerun](https://github.com/computmaxer/roku-hdhomerun), which doesn't allow you to change the defaults.
