### PR TITLE
Fix HDHomeRun Prime link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :zap: Wallop :zap:
 
-Wallop is a transcoding server for your [HDHomeRun Prime](http://www.silicondust.com/products/hdhomerun/prime/).
+Wallop is a transcoding server for your [HDHomeRun Prime](https://www.silicondust.com/product/hdhomerun-prime/).
 
 Wallop lets you watch TV streams on your iPhone, iPad, Roku, Web, Android device. Even away from home.
 


### PR DESCRIPTION
The current one returns 404. Googling lead me to the new one.