### PR TITLE
Channel logo support for OTA channels which contanin periods

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -21,3 +21,4 @@ options = "-loglevel warning -async 1  -tune zerolatency -flags -global_header -
 508 = "abc.png"
 511 = "fox.png"
 512 = "nbc.png"
+5-1 = "pbs.png"

--- a/lib/wallop.rb
+++ b/lib/wallop.rb
@@ -127,8 +127,14 @@ module Wallop
     lineup = @lineup ||= JSON.parse(open(hdhomerun_lineup_url).read)
     lineup.each do |l|
       l['Favorite'] = false
+
+      # To avoid toml key parsing errors, allow the use of hyphens instead of periods in config.toml logo configs (common for OTA channels)
+      guide_number_hyphens = l['GuideNumber'].sub('.','-')
+
       if config['channel_logos'][l['GuideNumber']]
         l['LogoUrl'] = "#{request_url}/logos/#{config['channel_logos'][l['GuideNumber']]}"
+      elsif config['channel_logos'][guide_number_hyphens]
+        l['LogoUrl'] = "#{request_url}/logos/#{config['channel_logos'][guide_number_hyphens]}"
       else
         l['LogoUrl'] = nil
       end


### PR DESCRIPTION
When attempting to add channel logo configurations for OTA channels which contain period characters, toml errors were received.  Attempted to quote the key as recommended in the toml documentation without success.  This PR allows the use of hyphens instead by adding a condition with a simple substitution.

Considered using sub! to avoid an additional condition, but decided not to do this to avoid potential regressions such as the channel name appearing with a dash instead of a period in the application and web interfaces.

Example error when period is used:
```
5.1 = "pbs.png"
```
```
wallop$ script/server
Failed to match sequence (ALL_SPACE (TABLE / TABLE_ARRAY / KEY_VALUE / COMMENT_LINE){0, } ALL_SPACE) at line 22 char 1.
`- Don't know what to do with "5.1 = \"pbs" at line 22 char 1.
/home/public/dev/wallop/lib/wallop.rb:54:in `expand_path': can't convert nil into String (TypeError)
	from /home/public/dev/wallop/lib/wallop.rb:54:in `transcoding_path'
	from /home/public/dev/wallop/lib/wallop.rb:59:in `setup'
	from /home/public/dev/wallop/app/boot.rb:22:in `<top (required)>'
	from app/app.rb:2:in `require'
	from app/app.rb:2:in `<main>'
```

The error is not received when hyphens are used with the added condition present:
```
5-1 = "pbs.png"
```
```
"GET /logos/pbs.png HTTP/1.1" 200
```